### PR TITLE
Fix attribute parsing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@
   `Reader::into_underlying_reader()` to `Reader::into_inner()`
 - refactor: now `Attributes::next()` returns a new type `AttrError` when attribute parsing failed
   ([#4](https://github.com/Mingun/fast-xml/pull/4))
+- test: properly test all paths of attributes parsing ([#4](https://github.com/Mingun/fast-xml/pull/4))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,8 @@
   ([quick-xml#311](https://github.com/tafia/quick-xml/issues/311))
 - feat: add `Reader::get_ref()` and `Reader::get_mut()`, rename
   `Reader::into_underlying_reader()` to `Reader::into_inner()`
+- refactor: now `Attributes::next()` returns a new type `AttrError` when attribute parsing failed
+  ([#4](https://github.com/Mingun/fast-xml/pull/4))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,9 @@
 - refactor: now `Attributes::next()` returns a new type `AttrError` when attribute parsing failed
   ([#4](https://github.com/Mingun/fast-xml/pull/4))
 - test: properly test all paths of attributes parsing ([#4](https://github.com/Mingun/fast-xml/pull/4))
+- feat: attribute iterator now implements `FusedIterator` ([#4](https://github.com/Mingun/fast-xml/pull/4))
+- fix: fixed many errors in attribute parsing using iterator, returned from `attributes()`
+  or `html_attributes()` ([#4](https://github.com/Mingun/fast-xml/pull/4))
 
 ## 0.23.0-alpha3
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -219,4 +219,11 @@ pub mod serialize {
             DeError::Float(e)
         }
     }
+
+    impl From<AttrError> for DeError {
+        #[inline]
+        fn from(e: AttrError) -> Self {
+            DeError::Xml(e.into())
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,8 +27,6 @@ pub enum Error {
     TextNotFound,
     /// `Event::XmlDecl` must start with *version* attribute
     XmlDeclWithoutVersion(Option<String>),
-    /// Attribute Name contains quote, position relative to start of owning tag is provided
-    NameWithQuote(usize),
     /// Attribute key not followed by with `=`, position relative to start of owning tag is provided
     NoEqAfterName(usize),
     /// Attribute value not quoted, position relative to start of owning tag is provided
@@ -89,12 +87,6 @@ impl std::fmt::Display for Error {
             Error::XmlDeclWithoutVersion(e) => write!(
                 f,
                 "XmlDecl must start with 'version' attribute, found {:?}",
-                e
-            ),
-            Error::NameWithQuote(e) => write!(
-                f,
-                "error while parsing attribute at position {}: \
-                 Attribute key cannot contain quote",
                 e
             ),
             Error::NoEqAfterName(e) => write!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,13 +27,15 @@ pub enum Error {
     TextNotFound,
     /// `Event::XmlDecl` must start with *version* attribute
     XmlDeclWithoutVersion(Option<String>),
-    /// Attribute Name contains quote
+    /// Attribute Name contains quote, position relative to start of owning tag is provided
     NameWithQuote(usize),
-    /// Attribute key not followed by with `=`
+    /// Attribute key not followed by with `=`, position relative to start of owning tag is provided
     NoEqAfterName(usize),
-    /// Attribute value not quoted
+    /// Attribute value not quoted, position relative to start of owning tag is provided
     UnquotedValue(usize),
-    /// Duplicate attribute
+    /// Duplicate attribute, positions relative to start of owning tag is provided:
+    /// - position of the duplicate
+    /// - previous position
     DuplicatedAttribute(usize, usize),
     /// Escape error
     EscapeError(EscapeError),
@@ -73,7 +75,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::Io(e) => write!(f, "I/O error: {}", e),
             Error::Utf8(e) => write!(f, "UTF8 error: {}", e),
-            Error::UnexpectedEof(e) => write!(f, "Unexpected EOF during reading {}.", e),
+            Error::UnexpectedEof(e) => write!(f, "Unexpected EOF during reading {}", e),
             Error::EndEventMismatch { expected, found } => {
                 write!(f, "Expecting </{}> found </{}>", expected, found)
             }
@@ -92,19 +94,19 @@ impl std::fmt::Display for Error {
             Error::NameWithQuote(e) => write!(
                 f,
                 "error while parsing attribute at position {}: \
-                 Attribute key cannot contain quote.",
+                 Attribute key cannot contain quote",
                 e
             ),
             Error::NoEqAfterName(e) => write!(
                 f,
                 "error while parsing attribute at position {}: \
-                 Attribute key must be directly followed by = or space",
+                 Attribute key must be directly followed by `=` or space",
                 e
             ),
             Error::UnquotedValue(e) => write!(
                 f,
                 "error while parsing attribute at position {}: \
-                 Attribute value must start with a quote.",
+                 Attribute value must start with a single or double quote",
                 e
             ),
             Error::DuplicatedAttribute(pos1, pos2) => write!(

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -7,62 +7,6 @@ use crate::escape::{do_unescape, escape};
 use crate::reader::{is_whitespace, Reader};
 use std::{borrow::Cow, collections::HashMap, io::BufRead, ops::Range};
 
-/// Iterator over XML attributes.
-///
-/// Yields `Result<Attribute>`. An `Err` will be yielded if an attribute is malformed or duplicated.
-/// The duplicate check can be turned off by calling [`with_checks(false)`].
-///
-/// [`with_checks(false)`]: #method.with_checks
-#[derive(Clone, Debug)]
-pub struct Attributes<'a> {
-    /// slice of `Element` corresponding to attributes
-    bytes: &'a [u8],
-    /// current position of the iterator
-    pub(crate) position: usize,
-    /// if true, checks for duplicate names
-    with_checks: bool,
-    /// allows attribute without quote or `=`
-    html: bool,
-    /// if `with_checks`, contains the ranges corresponding to the
-    /// attribute names already parsed in this `Element`
-    consumed: Vec<Range<usize>>,
-}
-
-impl<'a> Attributes<'a> {
-    /// Creates a new attribute iterator from a buffer.
-    pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
-        Attributes {
-            bytes: buf,
-            position: pos,
-            html: false,
-            with_checks: true,
-            consumed: Vec::new(),
-        }
-    }
-
-    /// Creates a new attribute iterator from a buffer, allowing HTML attribute syntax.
-    pub fn html(buf: &'a [u8], pos: usize) -> Attributes<'a> {
-        Attributes {
-            bytes: buf,
-            position: pos,
-            html: true,
-            with_checks: true,
-            consumed: Vec::new(),
-        }
-    }
-
-    /// Changes whether attributes should be checked for uniqueness.
-    ///
-    /// The XML specification requires attribute keys in the same element to be unique. This check
-    /// can be disabled to improve performance slightly.
-    ///
-    /// (`true` by default)
-    pub fn with_checks(&mut self, val: bool) -> &mut Attributes<'a> {
-        self.with_checks = val;
-        self
-    }
-}
-
 /// A struct representing a key/value XML attribute.
 ///
 /// Field `value` stores raw bytes, possibly containing escape-sequences. Most users will likely
@@ -330,6 +274,64 @@ impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
             key: val.0.as_bytes(),
             value: escape(val.1.as_bytes()),
         }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Iterator over XML attributes.
+///
+/// Yields `Result<Attribute>`. An `Err` will be yielded if an attribute is malformed or duplicated.
+/// The duplicate check can be turned off by calling [`with_checks(false)`].
+///
+/// [`with_checks(false)`]: #method.with_checks
+#[derive(Clone, Debug)]
+pub struct Attributes<'a> {
+    /// slice of `Element` corresponding to attributes
+    bytes: &'a [u8],
+    /// current position of the iterator
+    pub(crate) position: usize,
+    /// if true, checks for duplicate names
+    with_checks: bool,
+    /// allows attribute without quote or `=`
+    html: bool,
+    /// if `with_checks`, contains the ranges corresponding to the
+    /// attribute names already parsed in this `Element`
+    consumed: Vec<Range<usize>>,
+}
+
+impl<'a> Attributes<'a> {
+    /// Creates a new attribute iterator from a buffer.
+    pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
+        Attributes {
+            bytes: buf,
+            position: pos,
+            html: false,
+            with_checks: true,
+            consumed: Vec::new(),
+        }
+    }
+
+    /// Creates a new attribute iterator from a buffer, allowing HTML attribute syntax.
+    pub fn html(buf: &'a [u8], pos: usize) -> Attributes<'a> {
+        Attributes {
+            bytes: buf,
+            position: pos,
+            html: true,
+            with_checks: true,
+            consumed: Vec::new(),
+        }
+    }
+
+    /// Changes whether attributes should be checked for uniqueness.
+    ///
+    /// The XML specification requires attribute keys in the same element to be unique. This check
+    /// can be disabled to improve performance slightly.
+    ///
+    /// (`true` by default)
+    pub fn with_checks(&mut self, val: bool) -> &mut Attributes<'a> {
+        self.with_checks = val;
+        self
     }
 }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -386,9 +386,6 @@ impl<'a> Iterator for Attributes<'a> {
             .find(|&(_, &b)| b == b'=' || is_whitespace(b))
         {
             Some((i, &b'=')) => i,
-            Some((i, &b'\'')) | Some((i, &b'"')) if self.with_checks => {
-                err!(Error::NameWithQuote(i));
-            }
             Some((i, _)) => {
                 // consume until `=` or return if html
                 match bytes.by_ref().find(|&(_, &b)| !is_whitespace(b)) {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -456,7 +456,7 @@ impl<'a> BytesDecl<'a> {
                 Err(Error::XmlDeclWithoutVersion(Some(found)))
             }
             // error parsing attributes
-            Some(Err(e)) => Err(e),
+            Some(Err(e)) => Err(e.into()),
             // no attributes
             None => Err(Error::XmlDeclWithoutVersion(None)),
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -240,8 +240,6 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     /// Add additional attributes to this element using an iterator.
     ///
     /// The yielded items must be convertible to [`Attribute`] using `Into`.
-    ///
-    /// [`Attribute`]: attributes/struct.Attributes.html
     pub fn with_attributes<'b, I>(mut self, attributes: I) -> Self
     where
         I: IntoIterator,

--- a/tests/documents/html5.txt
+++ b/tests/documents/html5.txt
@@ -1,7 +1,7 @@
 DocType(html)
 Characters(
 )
-StartElement(a, attr-error: error while parsing attribute at position 7: Attribute value must start with a single or double quote)
+StartElement(a, attr-error: error while parsing attribute: position 7: attribute value must be enclosed in `"` or `'`)
 Characters(Hey)
 EndElement(a)
 Characters(

--- a/tests/documents/html5.txt
+++ b/tests/documents/html5.txt
@@ -1,7 +1,7 @@
 DocType(html)
 Characters(
 )
-StartElement(a, attr-error: error while parsing attribute at position 7: Attribute value must start with a quote.)
+StartElement(a, attr-error: error while parsing attribute at position 7: Attribute value must start with a single or double quote)
 Characters(Hey)
 EndElement(a)
 Characters(

--- a/tests/documents/html5.txt
+++ b/tests/documents/html5.txt
@@ -1,7 +1,7 @@
 DocType(html)
 Characters(
 )
-StartElement(a, attr-error: error while parsing attribute: position 7: attribute value must be enclosed in `"` or `'`)
+StartElement(a, attr-error: position 7: attribute value must be enclosed in `"` or `'`)
 Characters(Hey)
 EndElement(a)
 Characters(

--- a/tests/namespaces.rs
+++ b/tests/namespaces.rs
@@ -151,7 +151,7 @@ fn attributes_empty_ns() {
         e => panic!("Expecting Empty event, got {:?}", e),
     };
 
-    let mut atts = e
+    let mut attrs = e
         .attributes()
         .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
         // we don't care about xmlns attributes for this test
@@ -160,23 +160,19 @@ fn attributes_empty_ns() {
             let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
             (opt_ns, local_name, value)
         });
-    match atts.next() {
-        Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
-        e => panic!("Expecting att1='a' attribute, found {:?}", e),
-    }
-    match atts.next() {
-        Some((Some(ns), b"att2", Cow::Borrowed(b"b"))) => {
-            assert_eq!(&ns[..], b"urn:example:r");
-        }
-        e => panic!(
-            "Expecting {{urn:example:r}}att2='b' attribute, found {:?}",
-            e
-        ),
-    }
-    match atts.next() {
-        None => (),
-        e => panic!("Expecting None, found {:?}", e),
-    }
+    assert_eq!(
+        attrs.next(),
+        Some((None, &b"att1"[..], Cow::Borrowed(&b"a"[..])))
+    );
+    assert_eq!(
+        attrs.next(),
+        Some((
+            Some(&b"urn:example:r"[..]),
+            &b"att2"[..],
+            Cow::Borrowed(&b"b"[..])
+        ))
+    );
+    assert_eq!(attrs.next(), None);
 }
 
 /// Single empty element with qualified attributes.
@@ -196,7 +192,7 @@ fn attributes_empty_ns_expanded() {
             e => panic!("Expecting Empty event, got {:?}", e),
         };
 
-        let mut atts = e
+        let mut attrs = e
             .attributes()
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
@@ -205,23 +201,19 @@ fn attributes_empty_ns_expanded() {
                 let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
                 (opt_ns, local_name, value)
             });
-        match atts.next() {
-            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
-            e => panic!("Expecting att1='a' attribute, found {:?}", e),
-        }
-        match atts.next() {
-            Some((Some(ns), b"att2", Cow::Borrowed(b"b"))) => {
-                assert_eq!(&ns[..], b"urn:example:r");
-            }
-            e => panic!(
-                "Expecting {{urn:example:r}}att2='b' attribute, found {:?}",
-                e
-            ),
-        }
-        match atts.next() {
-            None => (),
-            e => panic!("Expecting None, found {:?}", e),
-        }
+        assert_eq!(
+            attrs.next(),
+            Some((None, &b"att1"[..], Cow::Borrowed(&b"a"[..])))
+        );
+        assert_eq!(
+            attrs.next(),
+            Some((
+                Some(&b"urn:example:r"[..]),
+                &b"att2"[..],
+                Cow::Borrowed(&b"b"[..])
+            ))
+        );
+        assert_eq!(attrs.next(), None);
     }
 
     match r.read_namespaced_event(&mut buf, &mut ns_buf) {
@@ -261,7 +253,7 @@ fn default_ns_shadowing_empty() {
             e => panic!("Expecting Empty event, got {:?}", e),
         };
 
-        let mut atts = e
+        let mut attrs = e
             .attributes()
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
@@ -272,14 +264,11 @@ fn default_ns_shadowing_empty() {
             });
         // the attribute should _not_ have a namespace name. The default namespace does not
         // apply to attributes.
-        match atts.next() {
-            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
-            e => panic!("Expecting att1='a' attribute, found {:?}", e),
-        }
-        match atts.next() {
-            None => (),
-            e => panic!("Expecting None, found {:?}", e),
-        }
+        assert_eq!(
+            attrs.next(),
+            Some((None, &b"att1"[..], Cow::Borrowed(&b"a"[..])))
+        );
+        assert_eq!(attrs.next(), None);
     }
 
     // </outer>
@@ -323,7 +312,7 @@ fn default_ns_shadowing_expanded() {
             }
             e => panic!("Expecting Start event (<inner>), got {:?}", e),
         };
-        let mut atts = e
+        let mut attrs = e
             .attributes()
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
@@ -334,14 +323,11 @@ fn default_ns_shadowing_expanded() {
             });
         // the attribute should _not_ have a namespace name. The default namespace does not
         // apply to attributes.
-        match atts.next() {
-            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
-            e => panic!("Expecting att1='a' attribute, found {:?}", e),
-        }
-        match atts.next() {
-            None => (),
-            e => panic!("Expecting None, found {:?}", e),
-        }
+        assert_eq!(
+            attrs.next(),
+            Some((None, &b"att1"[..], Cow::Borrowed(&b"a"[..])))
+        );
+        assert_eq!(attrs.next(), None);
     }
 
     // virtual </inner>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -32,25 +32,22 @@ fn test_attributes_empty() {
     let mut buf = Vec::new();
     match r.read_event(&mut buf) {
         Ok(Empty(e)) => {
-            let mut atts = e.attributes();
-            match atts.next() {
+            let mut attrs = e.attributes();
+            assert_eq!(
+                attrs.next(),
                 Some(Ok(Attribute {
                     key: b"att1",
                     value: Cow::Borrowed(b"a"),
-                })) => (),
-                e => panic!("Expecting att1='a' attribute, found {:?}", e),
-            }
-            match atts.next() {
+                }))
+            );
+            assert_eq!(
+                attrs.next(),
                 Some(Ok(Attribute {
                     key: b"att2",
                     value: Cow::Borrowed(b"b"),
-                })) => (),
-                e => panic!("Expecting att2='b' attribute, found {:?}", e),
-            }
-            match atts.next() {
-                None => (),
-                e => panic!("Expecting None, found {:?}", e),
-            }
+                }))
+            );
+            assert_eq!(attrs.next(), None);
         }
         e => panic!("Expecting Empty event, got {:?}", e),
     }
@@ -64,18 +61,15 @@ fn test_attribute_equal() {
     let mut buf = Vec::new();
     match r.read_event(&mut buf) {
         Ok(Empty(e)) => {
-            let mut atts = e.attributes();
-            match atts.next() {
+            let mut attrs = e.attributes();
+            assert_eq!(
+                attrs.next(),
                 Some(Ok(Attribute {
                     key: b"att1",
                     value: Cow::Borrowed(b"a=b"),
-                })) => (),
-                e => panic!("Expecting att1=\"a=b\" attribute, found {:?}", e),
-            }
-            match atts.next() {
-                None => (),
-                e => panic!("Expecting None, found {:?}", e),
-            }
+                }))
+            );
+            assert_eq!(attrs.next(), None);
         }
         e => panic!("Expecting Empty event, got {:?}", e),
     }

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -227,8 +227,8 @@ fn issue_83_duplicate_attributes() {
         r#"<hello><some-tag a='10' a="20"/></hello>"#,
         "
             |StartElement(hello)
-            |1:30 EmptyElement(some-tag, attr-error: error while parsing \
-                  attribute at position 16: Duplicate attribute at position 9 and 16)
+            |1:30 EmptyElement(some-tag, attr-error: error while parsing attribute: \
+                  position 16: duplicated attribute, previous declaration at position 9)
             |EndElement(hello)
             |EndDocument
         ",

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -227,7 +227,7 @@ fn issue_83_duplicate_attributes() {
         r#"<hello><some-tag a='10' a="20"/></hello>"#,
         "
             |StartElement(hello)
-            |1:30 EmptyElement(some-tag, attr-error: error while parsing attribute: \
+            |1:30 EmptyElement(some-tag, attr-error: \
                   position 16: duplicated attribute, previous declaration at position 9)
             |EndElement(hello)
             |EndDocument

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -161,7 +161,7 @@ fn sample_ns_short() {
 fn eof_1() {
     test(
         r#"<?xml"#,
-        r#"Error: Unexpected EOF during reading XmlDecl."#,
+        r#"Error: Unexpected EOF during reading XmlDecl"#,
         true,
     );
 }
@@ -170,7 +170,7 @@ fn eof_1() {
 fn bad_1() {
     test(
         r#"<?xml&.,"#,
-        r#"1:6 Error: Unexpected EOF during reading XmlDecl."#,
+        r#"1:6 Error: Unexpected EOF during reading XmlDecl"#,
         true,
     );
 }


### PR DESCRIPTION
This PR adds tests for attribute parsing and fixes bugs found. It introduces new `AttrError` type that now returned by `Attributes::next()` and contains all possible errors when attributes is parsed.

Also it introduces a new type `Attr` which is by design is borrowed-only. In version 0.24 I plan to change `Attributes` iterator and return that new type.
 
@dralley, it would be great to run performance tests and see the results and maybe make optimizations like that you've done in #3