### PR TITLE
Add more XML libraries to comparison

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -18,6 +18,7 @@ rapid-xml = "0.2"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"
+rusty_xml = { version = "0.3", package = "RustyXML" }
 
 [[bench]]
 name = "bench"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -11,6 +11,7 @@ criterion = "0.3"
 fast-xml = { path = "..", features = ["serialize"] }
 xml-rs = "0.8"
 xml5ever = "0.17"
+xmlparser = "0.13"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dev-dependencies]
 criterion = "0.3"
 fast-xml = { path = "..", features = ["serialize"] }
+maybe_xml = "0.2"
 xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dev-dependencies]
 criterion = "0.3"
 fast-xml = { path = "..", features = ["serialize"] }
+xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 criterion = "0.3"
 fast-xml = { path = "..", features = ["serialize"] }
 xml-rs = "0.8"
+xml5ever = "0.17"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -13,6 +13,7 @@ xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"
+rapid-xml = "0.2"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -1,6 +1,6 @@
 use criterion::{self, criterion_group, criterion_main, Criterion};
-use pretty_assertions::assert_eq;
 use fast_xml::{self, events::Event, Reader};
+use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serde_xml_rs;
 use xml::reader::{EventReader, XmlEvent};
@@ -26,6 +26,38 @@ fn low_level_comparison(c: &mut Criterion) {
                 buf.clear();
             }
             assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
+    group.bench_function("xml5ever", |b| {
+        use xml5ever::buffer_queue::BufferQueue;
+        use xml5ever::tokenizer::{TagKind, Token, TokenSink, XmlTokenizer};
+
+        struct Sink(usize);
+        impl TokenSink for Sink {
+            fn process_token(&mut self, token: Token) {
+                match token {
+                    Token::TagToken(tag) if tag.kind == TagKind::StartTag => self.0 += 1,
+                    Token::TagToken(tag) if tag.kind == TagKind::EmptyTag => self.0 += 1,
+                    _ => (),
+                }
+            }
+        }
+
+        // Copied from xml5ever benchmarks
+        // https://github.com/servo/html5ever/blob/429f23943b24f739b78f4d703620d7b1b526475b/xml5ever/benches/xml5ever.rs
+        b.iter(|| {
+            let sink = criterion::black_box(Sink(0));
+            let mut tok = XmlTokenizer::new(sink, Default::default());
+            let mut buffer = BufferQueue::new();
+            buffer.push_back(SOURCE.into());
+            let _ = tok.feed(&mut buffer);
+            tok.end();
+
+            assert_eq!(
+                tok.sink.0, 1550,
+                "Overall tag count in ./tests/sample_rss.xml"
+            );
         })
     });
 

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -87,6 +87,24 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("RustyXML", |b| {
+        use rusty_xml::{Event, Parser};
+
+        b.iter(|| {
+            let mut r = Parser::new();
+            r.feed_str(SOURCE);
+
+            let mut count = criterion::black_box(0);
+            for event in r {
+                match event.unwrap() {
+                    Event::ElementStart(_) => count += 1,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml_oxide", |b| {
         use xml_oxide::sax::parser::Parser;
         use xml_oxide::sax::Event;

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -44,6 +44,26 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("xml_oxide", |b| {
+        use xml_oxide::sax::parser::Parser;
+        use xml_oxide::sax::Event;
+
+        b.iter(|| {
+            let mut r = Parser::from_reader(SOURCE.as_bytes());
+
+            let mut count = criterion::black_box(0);
+            loop {
+                // Makes no progress if error is returned, so need unwrap()
+                match r.read_event().unwrap() {
+                    Event::StartElement(_) => count += 1,
+                    Event::EndDocument => break,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml5ever", |b| {
         use xml5ever::buffer_queue::BufferQueue;
         use xml5ever::tokenizer::{TagKind, Token, TokenSink, XmlTokenizer};

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -29,6 +29,21 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("xmlparser", |b| {
+        use xmlparser::{Token, Tokenizer};
+
+        b.iter(|| {
+            let mut count = criterion::black_box(0);
+            for token in Tokenizer::from(SOURCE) {
+                match token {
+                    Ok(Token::ElementStart { .. }) => count += 1,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml5ever", |b| {
         use xml5ever::buffer_queue::BufferQueue;
         use xml5ever::tokenizer::{TagKind, Token, TokenSink, XmlTokenizer};


### PR DESCRIPTION
We still 2-3x faster than `xmlparser`, `xml5ever` on the third, `xml-rs` is outsider.

Rough run on my notebook
```
low-level API/fast_xml  time:   [248.44 us 261.39 us 276.66 us]
                        change: [+75.497% +104.05% +139.32%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
low-level API/xml_rs    time:   [14.415 ms 14.940 ms 15.524 ms]
                        change: [+28.625% +34.300% +39.581%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
low-level API/xml5ever  time:   [5.3598 ms 5.4856 ms 5.6368 ms]
                        change: [-13.234% -9.9922% -6.4032%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
low-level API/xmlparser time:   [682.64 us 688.38 us 695.22 us]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
```

@jdm, you are merging last PRs in xml5ever -- if you or other of your team interested, an you look at the benchmark code? I would like to count tags as the first two benchmarks do.

@RazrFalcon, if you interested, could you look at benchmark code for xmlparser? I'm not sure that it is idiomatic code, moreover, I would like to count tags as the first two benchmarks do.