### PR TITLE
Fix of erroneously accepted input when deserializing scalars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,7 +26,12 @@
   |`DeError::EndOfAttributes`|Renamed to `DeError::KeyNotFound`
   |`DeError::ExpectedStart`|Added
 
+### New Tests
+
+- [#9]: Added tests for incorrect nested tags in input
+
 [#8]: https://github.com/Mingun/fast-xml/pull/8
+[#9]: https://github.com/Mingun/fast-xml/pull/9
 
 ## 0.23.0 -- 2022-05-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- [#9]: Deserialization erroneously was successful in some cases where error is expected.
+  This broke deserialization of untagged enums which rely on error if variant cannot be parsed
+
 ### Misc Changes
 
 - [#8]: Changes in the error type `DeError`:

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -316,6 +316,15 @@ mod trivial {
                     let item: Trivial<$type> = from_str($value).unwrap();
 
                     assert_eq!(item, Trivial { value: $expected });
+
+                    match from_str::<Trivial<$type>>(&format!("<outer>{}</outer>", $value)) {
+                        // Expected unexpected start element `<root>`
+                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"root"),
+                        x => panic!(
+                            r#"Expected `Err(DeError::UnexpectedStart("root"))`, but got `{:?}`"#,
+                            x
+                        ),
+                    }
                 }
             };
         }


### PR DESCRIPTION
This PR fixes the following situation, when
```rust
#[derive(Deserialize)]
struct AnyName {
  field: usize, // or any other number / string / boolean
}
```
is successfully deserialized from
```xml
<any-tag>
  <field><any-tag>42</any-tag></field>
<any-tag>
```
when it shouldn't.